### PR TITLE
fix: 'name' column to 'text_jp'

### DIFF
--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -20,7 +20,7 @@ class Category extends Model
      * @var array
      */
     protected $fillable = [
-        'name',
+        'text_jp',
         'parent_category_id',
     ];
 

--- a/app/Models/Level.php
+++ b/app/Models/Level.php
@@ -19,7 +19,7 @@ class Level extends Model
      * @var array
      */
     protected $fillable = [
-        'name',
+        'text_jp',
     ];
 
     public function tasks()

--- a/app/Models/ParentCategory.php
+++ b/app/Models/ParentCategory.php
@@ -19,7 +19,7 @@ class ParentCategory extends Model
      * @var array
      */
     protected $fillable = [
-        'name',
+        'text_jp',
     ];
 
     public function categories()

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -22,7 +22,7 @@ class Task extends Model
     protected $fillable = [
         'level_id',
         'category_id',
-        'name',
+        'text_jp',
         'description',
     ];
 

--- a/database/migrations/2021_08_24_004329_drop_name_from_parent_categories_table.php
+++ b/database/migrations/2021_08_24_004329_drop_name_from_parent_categories_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DropNameFromParentCategoriesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('parent_categories', function (Blueprint $table) {
+            $table->dropColumn('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('parent_categories', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/database/migrations/2021_08_24_004447_drop_name_from_categories_table.php
+++ b/database/migrations/2021_08_24_004447_drop_name_from_categories_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DropNameFromCategoriesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->dropColumn('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/database/migrations/2021_08_24_004547_drop_name_from_levels_table.php
+++ b/database/migrations/2021_08_24_004547_drop_name_from_levels_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DropNameFromLevelsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('levels', function (Blueprint $table) {
+            $table->dropColumn('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('levels', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/database/migrations/2021_08_24_004700_drop_name_from_tasks_table.php
+++ b/database/migrations/2021_08_24_004700_drop_name_from_tasks_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DropNameFromTasksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->dropColumn('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/database/migrations/2021_08_24_004905_add_text_jp_to_parent_categories_table.php
+++ b/database/migrations/2021_08_24_004905_add_text_jp_to_parent_categories_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddTextJpToParentCategoriesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('parent_categories', function (Blueprint $table) {
+            $table->string('text_jp', 256);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('parent_categories', function (Blueprint $table) {
+            $table->dropColumn('text_jp');
+        });
+    }
+}

--- a/database/migrations/2021_08_24_005015_add_text_jp_to_categories_table.php
+++ b/database/migrations/2021_08_24_005015_add_text_jp_to_categories_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddTextJpToCategoriesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->string('text_jp', 256);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/database/migrations/2021_08_24_005055_add_text_jp_to_levels_table.php
+++ b/database/migrations/2021_08_24_005055_add_text_jp_to_levels_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddTextJpToLevelsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('levels', function (Blueprint $table) {
+            $table->string('text_jp', 32);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('levels', function (Blueprint $table) {
+            $table->dropColumn('text_jp');
+        });
+    }
+}

--- a/database/migrations/2021_08_24_005205_add_text_jp_to_tasks_table.php
+++ b/database/migrations/2021_08_24_005205_add_text_jp_to_tasks_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddTextJpToTasksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->string('text_jp', 1024);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->string('text_jp');
+        });
+    }
+}

--- a/database/seeders/TaskSeeder.php
+++ b/database/seeders/TaskSeeder.php
@@ -21,25 +21,25 @@ class TaskSeeder extends Seeder
     { 
 
         // Insert parent category samples
-        $parentRemoteTool = ParentCategory::create(['name' => 'リモートツール利用']);
-        $parentEnvironment = ParentCategory::create(['name' => '環境デザイン']);
+        $parentRemoteTool = ParentCategory::create(['text_jp' => 'リモートツール利用']);
+        $parentEnvironment = ParentCategory::create(['text_jp' => '環境デザイン']);
 
         
         // Insert category samples
         $remoteTool = Category::create([
-            'name' => 'リモートツールワーク利用',
+            'text_jp' => 'リモートツールワーク利用',
             'parent_category_id' => $parentRemoteTool->id,
         ]);
         $environment = Category::create([
-            'name' => '環境デザイン',
+            'text_jp' => '環境デザイン',
             'parent_category_id' => $parentEnvironment->id,
         ]);
 
 
         // Insert level samples
-        $beginner = Level::create(['name' => '初級']);
-        $intermediate = Level::create(['name' => '中級']);
-        $advanced = Level::create(['name' => '上級']);
+        $beginner = Level::create(['text_jp' => '初級']);
+        $intermediate = Level::create(['text_jp' => '中級']);
+        $advanced = Level::create(['text_jp' => '上級']);
 
 
 
@@ -47,25 +47,25 @@ class TaskSeeder extends Seeder
         Task::create([
             'level_id' => $beginner->id,
             'category_id' => $remoteTool->id,
-            'name' => '下記のSlackの基本的な使い方を実施している',
+            'text_jp' => '下記のSlackの基本的な使い方を実施している',
             'description' => '',
         ]);
         Task::create([
             'level_id' => $intermediate->id,
             'category_id' => $remoteTool->id,
-            'name' => 'バーチャルオフィスツールoViceを３回以上利用したことがある',
+            'text_jp' => 'バーチャルオフィスツールoViceを３回以上利用したことがある',
             'description' => '',
         ]);
         Task::create([
             'level_id' => $beginner->id,
             'category_id' => $environment->id,
-            'name' => '自宅での作業環境を、自宅の環境・制約がある中でも、自身なりに工夫して構築した。必ずしも最適な環境が整っている必要はない',
+            'text_jp' => '自宅での作業環境を、自宅の環境・制約がある中でも、自身なりに工夫して構築した。必ずしも最適な環境が整っている必要はない',
             'description' => '',
         ]);
         Task::create([
             'level_id' => $intermediate->id,
             'category_id' => $environment->id,
-            'name' => 'SNSに依存しないように、見るタイミングを定めて概ねコントロールができている（１週間の中で４日以上）',
+            'text_jp' => 'SNSに依存しないように、見るタイミングを定めて概ねコントロールができている（１週間の中で４日以上）',
             'description' => '',
         ]);
     }


### PR DESCRIPTION
## 実装内容

* parent_categories, categories, levelsの'name'列を'text_jp'に変更。

## できるようになること（ユーザ目線）

* カテゴリやタスクのテキストを'name'ではなく、'text_jp'で取得することになる

## 動作確認

* remigration成功

## コメント

* 文脈上、'name'は不適切だと考えて変更しました。今後、英語のテキストを追加することなども加味してsuffixに'jp'を追加しています。